### PR TITLE
Forms documentation

### DIFF
--- a/app/client/components/guide/route.forms.ui.js
+++ b/app/client/components/guide/route.forms.ui.js
@@ -1,0 +1,9 @@
+// for route /styleguide/forms
+Q.components.route.styleguide.ui.forms = {
+  items: [
+    {
+      guide: m.component(Q.components.guide.styleguide.ui.forms.container),
+      code: Q.code.forms
+    }
+  ]
+};

--- a/app/server/layouts/menu.html
+++ b/app/server/layouts/menu.html
@@ -12,6 +12,7 @@
     <li><a href="/styleguide/elements">Elements</a></li>
     <li><a href="/styleguide/icons">Icons</a></li>
     <li><a href="/styleguide/tables">Tables</a></li>
+    <li><a href="/styleguide/forms">Forms</a></li>
   </ul>
 
   <h2 class="head-5 head--gray margin-top-xlarge padding-bottom-medium">Javascript</h2>

--- a/build/_app.js
+++ b/build/_app.js
@@ -20,6 +20,7 @@ let Manifest = [
   'app/client/components/guide/route.typography.ui.js',
   'app/client/components/guide/route.mithril.ui.js',
   'app/client/components/guide/route.components.ui.js',
+  'app/client/components/guide/route.forms.ui.js',
 
   /* routes */
   'app/client/routes.js'

--- a/quartz-css/vhx-style-forms/docs/code/forms.html
+++ b/quartz-css/vhx-style-forms/docs/code/forms.html
@@ -1,0 +1,18 @@
+<!-- Standard -->
+<form class="form border radius padding-medium">
+  <fieldset class="margin-bottom-medium">
+    <label for="user_name">User name</label>
+    <input type="text" name="user_name" placeholder="Enter a your user_name">
+  </fieldset>
+  <fieldset class="margin-bottom-medium">
+    <label for="email">Email</label>
+    <input type="email" name="email" placeholder="Enter your email">
+  </fieldset>
+  <fieldset class="margin-bottom-medium">
+    <label for="message">Enter your message</label>
+    <textarea type="message" name="message" placeholder="Enter a message"></textarea>
+  </fieldset>
+  <div class="clearfix">
+    <button type="submit" class="btn-teal right">Submit</button>
+  </div>
+</form>

--- a/quartz-css/vhx-style-forms/docs/code/forms.html
+++ b/quartz-css/vhx-style-forms/docs/code/forms.html
@@ -1,17 +1,25 @@
 <!-- Standard -->
 <form class="form border radius padding-medium">
+
+  <!-- Standard input -->
   <fieldset class="margin-bottom-medium">
     <label for="user_name">User name</label>
     <input type="text" name="user_name" placeholder="Enter a your user_name">
   </fieldset>
+
+  <!-- Disabled input -->
   <fieldset class="margin-bottom-medium">
     <label for="secret_key">Secret Key (disabled)</label>
     <input type="number" name="secret_key" disabled="" placeholder="Enter your secret key (disabled)">
   </fieldset>
+
+  <!-- Input error state -->
   <fieldset class="margin-bottom-medium">
     <label for="domain_name">Domain Name (error)</label>
     <input type="text" name="domain_name" placeholder="Enter your domain name (error)" class="is-error">
   </fieldset>
+
+  <!-- Input with inner button -->
   <fieldset class="margin-bottom-medium inner-button">
     <label for="domain_name">Domain Name (inner button)</label>
     <div class="inner-button">
@@ -19,14 +27,20 @@
       <button class="btn btn-teal btn--small">Verify Domain</button>
     </div>
   </fieldset>
+
+  <!-- Small input -->
   <fieldset class="margin-bottom-medium">
     <label for="state">State (small input)</label>
     <input type="text" name="state" placeholder="Enter your domain name (small input)" class="small">
   </fieldset>
+
+  <!-- Textarea input -->
   <fieldset class="margin-bottom-medium">
     <label for="message">Enter your message</label>
     <textarea type="message" name="message" placeholder="Enter a message"></textarea>
   </fieldset>
+
+  <!-- Submit button -->
   <div class="clearfix">
     <button type="submit" class="btn-teal right">Submit</button>
   </div>

--- a/quartz-css/vhx-style-forms/docs/code/forms.html
+++ b/quartz-css/vhx-style-forms/docs/code/forms.html
@@ -5,8 +5,23 @@
     <input type="text" name="user_name" placeholder="Enter a your user_name">
   </fieldset>
   <fieldset class="margin-bottom-medium">
-    <label for="email">Email</label>
-    <input type="email" name="email" placeholder="Enter your email">
+    <label for="secret_key">Secret Key (disabled)</label>
+    <input type="number" name="secret_key" disabled="" placeholder="Enter your secret key (disabled)">
+  </fieldset>
+  <fieldset class="margin-bottom-medium">
+    <label for="domain_name">Domain Name (error)</label>
+    <input type="text" name="domain_name" placeholder="Enter your domain name (error)" class="is-error">
+  </fieldset>
+  <fieldset class="margin-bottom-medium inner-button">
+    <label for="domain_name">Domain Name (inner button)</label>
+    <div class="inner-button">
+      <input type="text" name="domain_name" placeholder="Enter your domain name">
+      <button class="btn btn-teal btn--small">Verify Domain</button>
+    </div>
+  </fieldset>
+  <fieldset class="margin-bottom-medium">
+    <label for="state">State (small input)</label>
+    <input type="text" name="state" placeholder="Enter your domain name (small input)" class="small">
   </fieldset>
   <fieldset class="margin-bottom-medium">
     <label for="message">Enter your message</label>

--- a/quartz-css/vhx-style-forms/docs/guide.html.js
+++ b/quartz-css/vhx-style-forms/docs/guide.html.js
@@ -4,8 +4,54 @@ Q.components.guide.styleguide.ui.forms.container = {
   view: function(ctrl) {
     return m('section#guide--style-forms', [
       m.component(Q.components.shared.intro.ui.container, {
-        title: 'Forms'
-      })
+        title: 'Forms',
+        intro: 'Form styling is offered inside of a <code>form</code> with a <code>form</code> class'
+      }),
+      m.component(Q.components.shared.block.ui.container, {
+        title: 'Standard',
+        component: {
+          view: function() {
+            return m('form.form.border.radius.padding-medium', [
+              m('fieldset.margin-bottom-medium', [
+                m('label', {
+                  for: 'user_name'
+                }, 'User name'),
+                m('input', {
+                  type: 'text',
+                  name: 'user_name',
+                  placeholder: 'Enter a your user_name'
+                })
+              ]),
+              m('fieldset.margin-bottom-medium', [
+                m('label', {
+                  for: 'email'
+                }, 'Email'),
+                m('input', {
+                  type: 'email',
+                  name: 'email',
+                  placeholder: 'Enter your email'
+                })
+              ]),
+              m('fieldset.margin-bottom-medium', [
+                m('label', {
+                  for: 'message'
+                }, 'Enter your message'),
+                m('textarea', {
+                  type: 'message',
+                  name: 'message',
+                  placeholder: 'Enter a message'
+                })
+              ]),
+              m('.clearfix',
+                m('button.btn-teal.right', {
+                  type: 'submit'
+                }, 'Submit')
+              )
+            ]);
+          }
+        }
+      }),
+
     ]);
   }
 };

--- a/quartz-css/vhx-style-forms/docs/guide.html.js
+++ b/quartz-css/vhx-style-forms/docs/guide.html.js
@@ -5,7 +5,7 @@ Q.components.guide.styleguide.ui.forms.container = {
     return m('section#guide--style-forms', [
       m.component(Q.components.shared.intro.ui.container, {
         title: 'Forms',
-        intro: 'Form styling is offered inside of a <code>form</code> with a <code>form</code> class'
+        intro: 'Form styling is offered inside of a <code>form</code> with a <code>form</code> class. Additional <code>input</code> styles are displayed below.'
       }),
       m.component(Q.components.shared.block.ui.container, {
         title: 'Standard',
@@ -24,12 +24,46 @@ Q.components.guide.styleguide.ui.forms.container = {
               ]),
               m('fieldset.margin-bottom-medium', [
                 m('label', {
-                  for: 'email'
-                }, 'Email'),
+                  for: 'secret_key'
+                }, 'Secret Key (disabled)'),
                 m('input', {
-                  type: 'email',
-                  name: 'email',
-                  placeholder: 'Enter your email'
+                  type: 'number',
+                  name: 'secret_key',
+                  disabled: true,
+                  placeholder: 'Enter your secret key (disabled)'
+                })
+              ]),
+              m('fieldset.margin-bottom-medium', [
+                m('label', {
+                  for: 'domain_name'
+                }, 'Domain Name (error)'),
+                m('input.is-error', {
+                  type: 'text',
+                  name: 'domain_name',
+                  placeholder: 'Enter your domain name (error)'
+                })
+              ]),
+              m('fieldset.margin-bottom-medium.inner-button', [
+                m('label', {
+                  for: 'domain_name'
+                }, 'Domain Name (inner button)'),
+                m('.inner-button', [
+                  m('input', {
+                    type: 'text',
+                    name: 'domain_name',
+                    placeholder: 'Enter your domain name'
+                  }),
+                  m('button.btn.btn-teal.btn--small', 'Verify Domain')
+                ])
+              ]),
+              m('fieldset.margin-bottom-medium', [
+                m('label', {
+                  for: 'state'
+                }, 'State (small input)'),
+                m('input.small', {
+                  type: 'text',
+                  name: 'state',
+                  placeholder: 'Enter your domain name (small input)'
                 })
               ]),
               m('fieldset.margin-bottom-medium', [


### PR DESCRIPTION
`<form>` styles have always been available in Quartz, but never documented. This PR introduces a `/forms` endpoint (and nav entry) with example markup and code that highlights key styles.

![quartz-forms](https://cloud.githubusercontent.com/assets/1396405/21937489/ac8d9d54-d985-11e6-98da-4fa762ddb1c3.png)
