### PR TITLE
<select> component UI bugfixes

### DIFF
--- a/quartz-js/components/select/styles/select.scss
+++ b/quartz-js/components/select/styles/select.scss
@@ -189,7 +189,7 @@
     max-width: 30%;
   }
   .c-media-item--content {
-    max-width: 70%;
+    max-width: 65%;
   }
 }
 

--- a/quartz-js/components/select/styles/select.scss
+++ b/quartz-js/components/select/styles/select.scss
@@ -121,10 +121,10 @@
   .c-select--dropdown {
     &:after, &:before {
       bottom: 100%;
-      right: 22px;
+      right: 11px;
     }
     &:before {
-      right: 23px;
+      right: 12px;
     }
   }
 }

--- a/quartz-js/components/select/ui/item.media.ui.js
+++ b/quartz-js/components/select/ui/item.media.ui.js
@@ -29,8 +29,8 @@ vhxm.components.shared.select.ui.item_media = {
         })
       ]),
       m('.c-media-item--content.clearfix.left', [
-        m('p.text--navy.line-medium', item[opts.prop_map.label]),
-        m('p.text--gray.line-medium', item[opts.prop_map.descriptor])
+        m('p.text--navy.line-medium.truncate.block', item[opts.prop_map.label]),
+        m('p.text--gray.line-medium.truncate.block', item[opts.prop_map.descriptor])
       ]),
       ctrl.parent.multiselect ? m('.c-media-item--action.clearfix.right', [
         ctrl.state.isProcessing().indexOf(item[opts.prop_map.value]) >= 0 ?


### PR DESCRIPTION
- correctly truncate lengthy strings in `media` items
- fix default dropdown caret position so it aligns with dropdown trigger

## string truncate (before / after)

![before](https://cloud.githubusercontent.com/assets/1396405/22038580/c5c6c8ee-dcc9-11e6-9049-ccdce6b64c85.png)
![after](https://cloud.githubusercontent.com/assets/1396405/22038582/c7c69958-dcc9-11e6-9f34-4d1748d842f9.png)

## caret position (before / after)
![caret-before](https://cloud.githubusercontent.com/assets/1396405/22038656/0b926112-dcca-11e6-94f7-eff860125136.png)
![caret-after](https://cloud.githubusercontent.com/assets/1396405/22038657/0f1d2e16-dcca-11e6-945b-a3618b61eed7.png)


