### PR TITLE
Add `label_length` option to the Tag and Select components

### DIFF
--- a/quartz-js/components/select/docs/guide.html.js
+++ b/quartz-js/components/select/docs/guide.html.js
@@ -104,16 +104,17 @@ Q.components.guide.js.ui.select.container = {
                 placeholder: 'Nothing selected',
                 selected: null,
                 action: 'Create new category',
+                label_length: 40,
                 items: m.prop([
                   {
                     id: 1,
-                    title: 'Media Item #1',
+                    title: 'Media Item #1: The First Media Item Listed',
                     detail: 'Item detail line',
                     img_src: 'https://placekitten.com/g/300/200'
                   },
                   {
                     id: 2,
-                    title: 'Media Item #2',
+                    title: 'Media Item #2: Numero Dos',
                     detail: 'Item #2 detail line',
                     img_src: 'https://placekitten.com/g/300/200'
                   },
@@ -179,6 +180,7 @@ Q.components.guide.js.ui.select.container = {
           { name: 'caret', type: 'string', default_value: 'right', description: m.trust('Specify the position of the caret. Either <span class="text--bold text--navy text-4">left</span>, <span class="text--bold text--navy text-4">center</span>, or <span class="text--bold text--navy text-4">right</span>.') },
           { name: 'offset', type: 'integer', default_value: '40', description: m.trust('Specify the offset of the dropdown from the trigger.') },
           { name: 'position', type: 'prop', default_value: 'bottom', description: m.trust('Specify the position of the dropdown. Either <span class="text--bold text--navy text-4">top</span> or <span class="text--bold text--navy text-4">bottom</span>.') },
+          { name: 'label_length', type: 'integer', default_value: '0 (unlimited)', description: m.trust('(Media Item only) Length of string to truncate after.') },
           { name: 'prop_map.key', type: 'string', required: true, description: 'The unique identifier (key) for each item selected (the selected object). The selected object will be returned in the onSelect callback method.' },
           { name: 'prop_map.value', type: 'string', required: true, description: 'Item key to look for in the provided items for the item value.' },
           { name: 'prop_map.label', type: 'string', required: true, description: 'Item key to look for in the provided items to display a label.' },

--- a/quartz-js/components/select/select.ui.js
+++ b/quartz-js/components/select/select.ui.js
@@ -9,6 +9,7 @@ vhxm.components.shared.select.ui.container = {
     options += opts.action ? '.has-action' : '';
     options += opts.type === 'media' ? '.has-media' : '';
     options += opts.inline ? '.inline' : '';
+    options += opts.label_length ? opts.label_length : 0;
     options += '.caret--' + (ctrl.position() === 'top' ? 'bottom' : 'top') + '-' + ctrl.caret;
 
     if (opts.trigger) {

--- a/quartz-js/components/select/ui/item.media.ui.js
+++ b/quartz-js/components/select/ui/item.media.ui.js
@@ -29,7 +29,10 @@ vhxm.components.shared.select.ui.item_media = {
         })
       ]),
       m('.c-media-item--content.clearfix.left', [
-        m('p.text--navy.line-medium.truncate.block', item[opts.prop_map.label]),
+        m('p.text--navy.line-medium.truncate.block', ctrl.formatLabelString({
+          label: item[opts.prop_map.label],
+          label_length: opts.label_length
+        })),
         m('p.text--gray.line-medium.truncate.block', item[opts.prop_map.descriptor])
       ]),
       ctrl.parent.multiselect ? m('.c-media-item--action.clearfix.right', [

--- a/quartz-js/components/select/ui/list.controller.js
+++ b/quartz-js/components/select/ui/list.controller.js
@@ -12,4 +12,13 @@ vhxm.components.shared.select.ui.list.controller = function(opts, parent) {
   self.handleItemClick = function(event, item) {
     self.parent.selectItem(item);
   };
+
+  self.formatLabelString = function(opts) {
+    if (opts.label && opts.label_length && (opts.label.length > opts.label_length)) {
+      return opts.label.substr(0, opts.label_length).trim() + '...';
+    }
+
+    return opts.label;
+  };
+
 };

--- a/quartz-js/components/tag/docs/code/tag.js
+++ b/quartz-js/components/tag/docs/code/tag.js
@@ -1,5 +1,7 @@
 m.component(vhxm.components.shared.tag.ui.container, {
-  label: 'Comedy',
+  label: 'My Series: Complete Series Package',
+  label_length: 20,
+  isProcessing: function() {},
   onShow: function() {
     window.alert('show something');
   },

--- a/quartz-js/components/tag/docs/guide.html.js
+++ b/quartz-js/components/tag/docs/guide.html.js
@@ -12,8 +12,21 @@ Q.components.guide.js.ui.tag.container = {
         component: {
           view: function() {
             return m('div', [
+              m('.margin-right-medium.left',
+                m.component(vhxm.components.shared.tag.ui.container, {
+                  label: 'My Series: Complete Series Package',
+                  label_length: 20,
+                  isProcessing: Q.fun,
+                  onShow: function() {
+                    window.alert('show something');
+                  },
+                  onRemove: function() {
+                    window.alert('remove something');
+                  }
+                })
+              ),
               m.component(vhxm.components.shared.tag.ui.container, {
-                label: 'Comedy',
+                label: 'Episode 1',
                 isProcessing: Q.fun,
                 onShow: function() {
                   window.alert('show something');
@@ -29,6 +42,7 @@ Q.components.guide.js.ui.tag.container = {
       m.component(Q.components.shared.options.ui.container, {
         options: [
           { name: 'label', type: 'string', default_value: 'Tag', description: m.trust('Text label of tag.') },
+          { name: 'label_length', type: 'integer', default_value: '0 (unlimited)', description: m.trust('Length of string to truncate after.') },
           { name: 'isProcessing', type: 'prop', required: false, default_value: 'false', description: 'Whether or not in a processing state. Requires redraw upon changing.' },
           { name: 'onShow', type: 'function', default_value: 'null', description: m.trust('Fired when the tag is clicked.') },
           { name: 'onRemove', type: 'function', default_value: 'null', description: m.trust('Fired when the remove action is clicked.') },

--- a/quartz-js/components/tag/tag.controller.js
+++ b/quartz-js/components/tag/tag.controller.js
@@ -12,4 +12,12 @@ vhxm.components.shared.tag.controller = function(opts) {
   if (opts.onRemove) {
     self.state.onRemove = opts.onRemove;
   }
+
+  self.formatLabelString = function(opts) {
+    if (opts.label && opts.label_length) {
+      return opts.label.substr(0, opts.label_length).trim() + '...';
+    }
+
+    return opts.label;
+  };
 };

--- a/quartz-js/components/tag/tag.controller.js
+++ b/quartz-js/components/tag/tag.controller.js
@@ -14,7 +14,7 @@ vhxm.components.shared.tag.controller = function(opts) {
   }
 
   self.formatLabelString = function(opts) {
-    if (opts.label && opts.label_length) {
+    if (opts.label && opts.label_length && (opts.label.length > opts.label_length)) {
       return opts.label.substr(0, opts.label_length).trim() + '...';
     }
 

--- a/quartz-js/components/tag/tag.ui.js
+++ b/quartz-js/components/tag/tag.ui.js
@@ -14,7 +14,7 @@ vhxm.components.shared.tag.ui.container = {
           event.preventDefault();
           ctrl.state.onShow(event);
         }
-      }, (opts.label ? opts.label : 'Tag')),
+      }, (opts.label ? ctrl.formatLabelString(opts) : 'Tag')),
       m('a.c-tag--remove.icon--center.icon-x-white.icon--xxsmall' + (ctrl.state.isRemoveHover() ? '.btn-red' : '.btn-teal'), {
         onclick: function(event) {
           event.preventDefault();


### PR DESCRIPTION
CSS-based string truncation wasn't working reliably because of how open-ended the implementation can be. 

Instead, a JS-based approach via a new `label_length` option allows folks to enforce string truncation after any number of characters they need.

### Screenshots

<img width="492" alt="select-media-item" src="https://cloud.githubusercontent.com/assets/1396405/22165218/b38e24b8-df28-11e6-99fe-ce937a75b70b.png">
<img width="358" alt="tag" src="https://cloud.githubusercontent.com/assets/1396405/22165217/b38e094c-df28-11e6-874d-3ee2b4413f6e.png">
