### PR TITLE
Add `checkedByDefault` and `api` options to radio component

### DIFF
--- a/quartz-js/components/filter/filter.ui.js
+++ b/quartz-js/components/filter/filter.ui.js
@@ -31,17 +31,19 @@ vhxm.components.shared.filter.ui.applied = {
     return parent_ctrl;
   },
   view: function(ctrl) {
+    let isSingle = ctrl.state.selected().length <= 1;
+
     return m('div', [
       ctrl.state.selected().map(function(item) {
         return m('span.c-filter--applied.inline', [
-          m('a.text--navy', {
+          m('a.text--navy' + (isSingle ? '.margin-right-small' : ''), {
             href: '#',
             onclick: function(event) {
               event.preventDefault();
               ctrl.openFilter(item);
             }
           }, item.label),
-          m('a.icon--center.icon-x-navy.icon--xxsmall', {
+          isSingle ? '' : m('a.icon--center.icon-x-navy.icon--xxsmall', {
             onclick: function(event) {
               event.preventDefault();
               ctrl.handleFilterRemoveClick(item);

--- a/quartz-js/components/radio/docs/guide.html.js
+++ b/quartz-js/components/radio/docs/guide.html.js
@@ -77,7 +77,7 @@ Q.components.guide.js.ui.radio.container = {
           { name: 'stacked', type: 'boolean', default_value: 'false', description: m.trust('Whether the radio elements are stacked vertically. Defaults to <span class="text--bold text--navy text-4">false</span> (horizontal layout).') },
           { name: 'color', type: 'string', default_value: 'teal', description: m.trust('The color of the radio buttons. Either <span class="text--navy text--bold text-4">teal</span> or <span class="text--navy text--bold text-4">gray</span>.') },
           { name: 'checkedByDefault', type: 'boolean', default_value: 'true', description: m.trust('Dictates whether a radio should be set as checked by default or not') },
-          { name: 'api', type: 'Mithril prop', default_value: 'false', description: m.trust('When set, surfaces direct access to internal component state') },
+          { name: 'api', type: 'Mithril prop', default_value: 'null', description: m.trust('When set, surfaces direct access to internal component state') },
         ]
       })
     ]);

--- a/quartz-js/components/radio/docs/guide.html.js
+++ b/quartz-js/components/radio/docs/guide.html.js
@@ -77,7 +77,7 @@ Q.components.guide.js.ui.radio.container = {
           { name: 'stacked', type: 'boolean', default_value: 'false', description: m.trust('Whether the radio elements are stacked vertically. Defaults to <span class="text--bold text--navy text-4">false</span> (horizontal layout).') },
           { name: 'color', type: 'string', default_value: 'teal', description: m.trust('The color of the radio buttons. Either <span class="text--navy text--bold text-4">teal</span> or <span class="text--navy text--bold text-4">gray</span>.') },
           { name: 'checkedByDefault', type: 'boolean', default_value: 'true', description: m.trust('Dictates whether a radio should be set as checked by default or not') },
-          { name: 'api', type: 'boolean', default_value: 'false', description: m.trust('When set to true, surfaces direct access to internal component state') },
+          { name: 'api', type: 'Mithril prop', default_value: 'false', description: m.trust('When set, surfaces direct access to internal component state') },
         ]
       })
     ]);

--- a/quartz-js/components/radio/docs/guide.html.js
+++ b/quartz-js/components/radio/docs/guide.html.js
@@ -76,6 +76,8 @@ Q.components.guide.js.ui.radio.container = {
           { name: 'onchange', type: 'function', default_value: null, description: m.trust('Callback fired when the the radio value changes.') },
           { name: 'stacked', type: 'boolean', default_value: 'false', description: m.trust('Whether the radio elements are stacked vertically. Defaults to <span class="text--bold text--navy text-4">false</span> (horizontal layout).') },
           { name: 'color', type: 'string', default_value: 'teal', description: m.trust('The color of the radio buttons. Either <span class="text--navy text--bold text-4">teal</span> or <span class="text--navy text--bold text-4">gray</span>.') },
+          { name: 'checkedByDefault', type: 'boolean', default_value: 'true', description: m.trust('Dictates whether a radio should be set as checked by default or not') },
+          { name: 'api', type: 'boolean', default_value: 'false', description: m.trust('When set to true, surfaces direct access to internal component state') },
         ]
       })
     ]);

--- a/quartz-js/components/radio/radio.controller.js
+++ b/quartz-js/components/radio/radio.controller.js
@@ -1,6 +1,10 @@
 vhxm.components.shared.radio.controller = function(opts) {
   let self = this;
+  opts = opts || {};
 
+  if (typeof opts.checkedByDefault === 'undefined') {
+    opts.checkedByDefault = true;
+  }
   self.state = new vhxm.components.shared.radio.state();
 
   opts.items.map(function(item){
@@ -9,7 +13,11 @@ vhxm.components.shared.radio.controller = function(opts) {
     }
   });
 
-  if (!self.state.isChecked()) {
+  if (opts.checkedByDefault && !self.state.isChecked()) {
     self.state.isChecked(opts.items[0].value);
+  }
+
+  if (opts.api) {
+    opts.api(self);
   }
 };


### PR DESCRIPTION
This PR adds two new options to the radio component:

- `checkedByDefault`: By default the first radio component in an array is set to `checked`. Setting this option to `false` leaves all radios unchecked instead (obligating user interaction).

- `api`: Setting this to an instance-specific state prop allows access to the radio components internal state.