### PR TITLE
remove aggressive redraw

### DIFF
--- a/quartz-js/components/sidebar/sidebar.model.js
+++ b/quartz-js/components/sidebar/sidebar.model.js
@@ -6,8 +6,6 @@ vhxm.components.shared.sidebar.toggle = function(state, route) {
     if (route) {
       return m.route(route);
     }
-
-    m.redraw();
   };
 
   if (vhxm.components.shared.sidebar.state.isOpen() && !state || !vhxm.components.shared.sidebar.state.isOpen() && state) {


### PR DESCRIPTION
Fixes sidebar animation bug that popped up once we moved to webpack.

@davegonzalez 