### PR TITLE
Add checkmark to selected item in dropdown

### DIFF
--- a/quartz-js/components/select/styles/select.scss
+++ b/quartz-js/components/select/styles/select.scss
@@ -165,6 +165,12 @@
     cursor: pointer;
     background-color: #F0F2F4;
   }
+  &.icon-check-navy {
+    background-size: 16px;
+  }
+  &.icon--right {
+    background-position: 95% 50%;
+  }
 }
 .c-select--item-label {
   max-width: 80%;

--- a/quartz-js/components/select/ui/item.standard.ui.js
+++ b/quartz-js/components/select/ui/item.standard.ui.js
@@ -8,7 +8,9 @@ vhxm.components.shared.select.ui.item_standard = {
     let ctrl  = params.ctrl;
     let opts  = params.opts;
 
-    return m('li.c-select--option.padding-horz-medium' + (index === ctrl.state.highlightIndex() ? '.is-selected' : ''), {
+    return m('li.c-select--option.padding-horz-medium' +
+      (item[opts.prop_map.label] === ctrl.parent.selectedLabel() ? '.icon-check-navy.icon--right' : '') +
+      (index === ctrl.state.highlightIndex() ? '.is-selected' : ''), {
       config: function(el) {
         ctrl.state.optionHeight($(el).outerHeight());
       },


### PR DESCRIPTION
This PR adds a checkmark next to the selected item in the `select` component. Only applies to the `standard` list item.

Asana: [The selected dropdown item should have a check next to it in the dropdown](https://app.asana.com/0/8583704912299/246070411064971)

### Screenshot
![screen shot 2017-02-27 at 4 16 31 pm](https://cloud.githubusercontent.com/assets/1396405/23380286/2cde449a-fd08-11e6-8529-e96975e2a756.png)

### In Action
![checkmark](https://cloud.githubusercontent.com/assets/1396405/23380282/2227db60-fd08-11e6-8e6e-17fd6a628545.gif)
