### PR TITLE
fix bug with allow inline select elements

### DIFF
--- a/quartz-js/components/select/select.ui.js
+++ b/quartz-js/components/select/select.ui.js
@@ -9,7 +9,6 @@ vhxm.components.shared.select.ui.container = {
     options += opts.action ? '.has-action' : '';
     options += opts.type === 'media' ? '.has-media' : '';
     options += opts.inline ? '.inline' : '';
-    options += opts.label_length ? opts.label_length : 0;
     options += '.caret--' + (ctrl.position() === 'top' ? 'bottom' : 'top') + '-' + ctrl.caret;
 
     if (opts.trigger) {


### PR DESCRIPTION
There was an unused `label_length` property that was causing the select container class to come back with a `0` and break the class adjacent to it.

This removes that option completely as I believe was originally intended.