### PR TITLE
Add px for checkbox icon margin

### DIFF
--- a/quartz-js/components/checkbox/styles/checkbox.scss
+++ b/quartz-js/components/checkbox/styles/checkbox.scss
@@ -82,7 +82,7 @@ $field-height: 40px;
       display: inline-block;
       width: $field-height;
       height: $field-height;
-      margin-right: 10;
+      margin-right: 10px;
       float: left;
       background-color: #fff;
       background-position: 50% 50%;


### PR DESCRIPTION
Needs a good old `px` for this to work.